### PR TITLE
Faster sorting by using compilation.chunkGroups

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Sorts webpack chunks by dependency
 import sortChunks from 'webpack-sort-chunks'
 
 const sortedChunks = sortChunks(stats.chunks)
+
+// If you hold on to the Webpack compilation, pass it as the second argument
+// It will be faster in Webpack >= v4
+const sortedChunks = sortChunks(stats.chunks, compilation)
 ```
 
 ## API

--- a/src/index.js
+++ b/src/index.js
@@ -6,18 +6,26 @@ type Chunk = {
   parents: (number | Chunk)[],
 }
 
-/**
- * Sort chunks by dependency
- */
-const sortChunks = (chunks: Chunk[]): Chunk[] => {
-  const chunkMap = chunks.reduce((result, chunk) => ({ ...result, [chunk.id]: chunk }), {})
+type ChunkMap = {
+  [number]: Chunk,
+}
+
+type Compilation = {
+  chunkGroups: {},
+}
+
+const sortWithChunks = (chunks: Chunk[], chunkMap: ChunkMap): Chunk[] => {
   const edges = []
 
   chunks.forEach((chunk) => {
     if (chunk.parents) {
+      // Add an edge for each parent (parent -> child)
       chunk.parents.forEach((parentId) => {
+        // webpack2 chunk.parents are chunks instead of string id(s)
         const parentChunk = typeof parentId === 'object' ? parentId : chunkMap[parentId]
 
+        // If the parent chunk does not exist (e.g.  because of an excluded chunk)
+        // we ignore that parent
         if (parentChunk) {
           edges.push([parentChunk, chunk])
         }
@@ -25,7 +33,53 @@ const sortChunks = (chunks: Chunk[]): Chunk[] => {
     }
   })
 
+  // We now perform a topological sorting on the input chunks and built edges
   return toposort.array(chunks, edges)
+}
+
+const sortWithChunkGroups = (chunkGroups: any, chunkMap: ChunkMap) => {
+  // Add an edge for each parent (parent -> child)
+  const edges = chunkGroups.reduce((result, chunkGroup) => result.concat(
+      Array.from(chunkGroup.parentsIterable, parentGroup => [parentGroup, chunkGroup])
+    ), [])
+
+    // We now perform a topological sorting on chunkGroups and built edges
+  const sortedGroups = toposort.array(chunkGroups, edges)
+
+    // Flatten chunkGroup into chunks
+  const sortedChunks = sortedGroups
+      .reduce((result, chunkGroup) => result.concat(chunkGroup.chunks), [])
+      .map(chunk => // Use the chunk from the list passed in, since it may be a filtered list
+        chunkMap[chunk.id])
+          .filter((chunk, index, self) => {
+            // Make sure exists (ie excluded chunks not in nodeMap)
+            const exists = !!chunk
+            // Make sure we have a unique list
+            const unique = self.indexOf(chunk) === index
+
+            return exists && unique
+          })
+
+  return sortedChunks
+}
+
+const sortChunks = (chunks: Chunk[], compilation?: Compilation): Chunk[] => {
+  // We build a map (chunk-id -> chunk) for faster access during graph building
+  const chunkMap = {}
+
+  chunks.forEach((chunk) => {
+    chunkMap[chunk.id] = chunk
+  })
+
+  // Before webpack 4 there was no chunkGroups
+  const chunkGroups = compilation && compilation.chunkGroups
+
+  if (!chunkGroups) {
+    return sortWithChunks(chunks, chunkMap)
+  }
+
+  // If there is chunkGroups, we use them because it's faster
+  return sortWithChunkGroups(chunkGroups, chunkMap)
 }
 
 export default sortChunks

--- a/test/index.js
+++ b/test/index.js
@@ -20,4 +20,26 @@ describe('sortChunks', () => {
     const chunks = [child, parent]
     expect(sortChunks(chunks)).toEqual([parent, child])
   })
+
+  it('returns sorted chunks using chunkGroup', () => {
+    const parent = { id: 1 }
+    const child = { id: 0, parents: [parent] }
+    const chunks = [child, parent]
+    const parentGroup = {
+      chunks: [parent],
+      parentsIterable: new Set([]),
+    }
+    const childGroup = {
+      chunks: [child],
+      parentsIterable: new Set([parentGroup]),
+    }
+    const compilation = {
+      chunkGroups: [
+        childGroup,
+        parentGroup,
+      ],
+    }
+
+    expect(sortChunks(chunks, compilation)).toEqual([parent, child])
+  })
 })


### PR DESCRIPTION
Based on the recent optimizations made on https://github.com/jantimon/html-webpack-plugin/blob/master/lib/chunksorter.js